### PR TITLE
implement granular permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,18 @@ With this simple fabric mod you can add a little color to your items with Chroma
 ## 🔒 Permissions
 If you have a permission plugin/mod like [LuckPerms](https://luckperms.net/), you are required to have the permission ``chromaanvils.use`` to be able to use it. If you don't have any permission plugins/mods, all players are able to use it.
 
+Additionally, you will also need to have the following permissions, corresponding to the formatting you want to allow:
+
+```properties
+chromaanvils.colors
+chromaanvils.decorations
+chromaanvils.font
+chromaanvils.gradient
+chromaanvils.rainbow
+chromaanvils.transition
+chromaanvils.reset
+```
+
 ## ✏️ Formating
 
 **Named colors**: black, dark_blue, dark_green, dark_aqua, dark_red, dark_purple, gold, gray, dark_gray, blue, green, aqua, red, light_purple, yellow, or white.

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ With this simple fabric mod you can add a little color to your items with Chroma
 
 🟢 **No mandatory client installation.**  
 🟢 **MiniMessage formating.**  
-🟢 **Permission support for server installation,.**  
+🟢 **Permission support for server installation.**  
 🟢 **Ability to blacklist items.**  
 🟢 **Extensive configs.**
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,22 +2,22 @@
 org.gradle.jvmargs=-Xmx3G
 
 # Mod Properties
-mod_version = 1.0.1
+mod_version = 1.0.2
 maven_group = fi.natroutter
 archives_base_name = ChromaAnvils
 
 # Plugins
-loom_version = 1.6-SNAPSHOT
+loom_version = 1.9-SNAPSHOT
 
-minecraft_version=1.21.1
-yarn_mappings=1.21.1+build.3
-loader_version=0.16.3
+minecraft_version=1.21.4
+yarn_mappings=1.21.4+build.2
+loader_version=0.16.9
 
 # Fabric API
-fabric_version=0.103.0+1.21.1
+fabric_version=0.111.0+1.21.4
 
 # Dependencies
-permission_api_version=0.3.1
-adventure_version=5.14.0
-cloth_version=15.0.127
-modmenu_version=11.0.1
+permission_api_version=0.3.3
+adventure_version=6.1.0
+cloth_version=17.0.142
+modmenu_version=13.0.0-beta.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@
 org.gradle.jvmargs=-Xmx3G
 
 # Mod Properties
-mod_version = 1.0.2
+mod_version = 1.0.3
 maven_group = fi.natroutter
 archives_base_name = ChromaAnvils
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/java/fi/natroutter/chromaanvils/ChromaAnvils.java
+++ b/src/main/java/fi/natroutter/chromaanvils/ChromaAnvils.java
@@ -7,7 +7,7 @@ import me.shedaniel.autoconfig.ConfigHolder;
 import me.shedaniel.autoconfig.serializer.Toml4jConfigSerializer;
 import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
-import net.kyori.adventure.platform.fabric.FabricServerAudiences;
+import net.kyori.adventure.platform.modcommon.MinecraftServerAudiences;
 
 public class ChromaAnvils implements ModInitializer {
 
@@ -20,9 +20,14 @@ public class ChromaAnvils implements ModInitializer {
 
     @Override
     public void onInitialize() {
+
         config = AutoConfig.register(ModConfig.class, Toml4jConfigSerializer::new);
 
-        ServerLifecycleEvents.SERVER_STARTED.register(server -> Colors.audiences = FabricServerAudiences.of(server));
-        ServerLifecycleEvents.SERVER_STOPPED.register(server -> Colors.audiences = null);
+        ServerLifecycleEvents.SERVER_STARTED.register(server -> {
+            Colors.serverAudiences = MinecraftServerAudiences.of(server);
+        });
+        ServerLifecycleEvents.SERVER_STOPPED.register(server -> {
+            Colors.serverAudiences = null;
+        });
     }
 }

--- a/src/main/java/fi/natroutter/chromaanvils/mixins/AnvilScreenMixin.java
+++ b/src/main/java/fi/natroutter/chromaanvils/mixins/AnvilScreenMixin.java
@@ -3,22 +3,28 @@ package fi.natroutter.chromaanvils.mixins;
 import com.llamalad7.mixinextras.sugar.Local;
 import fi.natroutter.chromaanvils.ChromaAnvils;
 import fi.natroutter.chromaanvils.utilities.Colors;
+import me.lucko.fabric.api.permissions.v0.Permissions;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import net.kyori.adventure.text.Component;
 import net.minecraft.client.gui.screen.ingame.AnvilScreen;
 import net.minecraft.client.gui.screen.ingame.ForgingScreen;
 import net.minecraft.client.gui.widget.TextFieldWidget;
+import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.entity.player.PlayerInventory;
 import net.minecraft.item.ItemStack;
 import net.minecraft.screen.AnvilScreenHandler;
+import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.text.Text;
 import net.minecraft.util.Identifier;
+import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import java.io.Console;
 
 @Mixin(AnvilScreen.class)
 public abstract class AnvilScreenMixin extends ForgingScreen<AnvilScreenHandler> {
@@ -29,6 +35,8 @@ public abstract class AnvilScreenMixin extends ForgingScreen<AnvilScreenHandler>
 
     @Shadow
     private TextFieldWidget nameField;
+
+    @Shadow @Final private PlayerEntity player;
 
     @Inject(method = "setup", at = @At(value = "TAIL"))
     public void setup(CallbackInfo ci) {
@@ -42,11 +50,16 @@ public abstract class AnvilScreenMixin extends ForgingScreen<AnvilScreenHandler>
             ordinal = 0
     ))
     private void updateResult(CallbackInfo ci, @Local(argsOnly = true) ItemStack stack) {
-        Text text = stack.getName();
-        String name = text.getString();
-        Component comp = text.asComponent();
+        if (this.player instanceof ServerPlayerEntity serverPlayer) {
+            boolean hasPerms = Permissions.check(serverPlayer, ChromaAnvils.MOD_ID + ".use", false);
+            if (!hasPerms) return;
+        }
 
-        if (comp.getClass().getTypeName().endsWith("TextComponentImpl")) {
+        Text text = stack.getName();
+        String name = text.getLiteralString();
+        Component comp = Colors.toAdventure(text);
+
+        if (comp != null && comp.getClass().getTypeName().endsWith("TextComponentImpl")) {
             name = Colors.serialize(comp);
         }
         nameField.setText(stack.isEmpty() ? "" : name);

--- a/src/main/java/fi/natroutter/chromaanvils/utilities/Colors.java
+++ b/src/main/java/fi/natroutter/chromaanvils/utilities/Colors.java
@@ -1,24 +1,18 @@
 package fi.natroutter.chromaanvils.utilities;
 
-import net.kyori.adventure.platform.fabric.FabricAudiences;
-import net.kyori.adventure.platform.fabric.FabricClientAudiences;
-import net.kyori.adventure.platform.fabric.FabricServerAudiences;
+import net.kyori.adventure.audience.Audience;
+import net.kyori.adventure.platform.modcommon.MinecraftClientAudiences;
+import net.kyori.adventure.platform.modcommon.MinecraftServerAudiences;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.minimessage.MiniMessage;
 import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
 import net.kyori.adventure.text.minimessage.tag.standard.StandardTags;
 import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
-import net.minecraft.client.MinecraftClient;
-import net.minecraft.entity.player.PlayerEntity;
-import net.minecraft.server.MinecraftServer;
 import net.minecraft.text.Text;
-import net.minecraft.world.World;
-
-import java.util.Objects;
 
 public class Colors {
 
-    public static volatile FabricAudiences audiences;
+    public static volatile MinecraftServerAudiences serverAudiences;
 
     public static MiniMessage miniMessage() {
         return MiniMessage.builder()
@@ -34,10 +28,12 @@ public class Colors {
                 ).build();
     }
 
-    public static FabricAudiences getAudience() {
-        //throw new IllegalStateException("Tried to access Adventure without a running server!");
-        if (audiences == null) return null;
-        return audiences;
+    public static MinecraftServerAudiences getServerAudience() {
+        if (serverAudiences == null) return null;
+        return serverAudiences;
+    }
+    public static MinecraftClientAudiences getClientAudience() {
+        return MinecraftClientAudiences.of();
     }
 
     public static String plain(Component component) {
@@ -53,8 +49,17 @@ public class Colors {
     }
 
     public static Text toNative(Component component) {
-        if (getAudience() == null) return null;
-        return getAudience().toNative(component);
+        if (getServerAudience() != null) {
+            return getServerAudience().asNative(component);
+        }
+        return getClientAudience().asNative(component);
+    }
+
+    public static Component toAdventure(Text text) {
+        if (getServerAudience() != null) {
+            return getServerAudience().asAdventure(text);
+        }
+        return getClientAudience().asAdventure(text);
     }
 
 }

--- a/src/main/java/fi/natroutter/chromaanvils/utilities/Colors.java
+++ b/src/main/java/fi/natroutter/chromaanvils/utilities/Colors.java
@@ -6,6 +6,7 @@ import net.kyori.adventure.platform.modcommon.MinecraftServerAudiences;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.minimessage.MiniMessage;
 import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
+import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver.Builder;
 import net.kyori.adventure.text.minimessage.tag.standard.StandardTags;
 import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
 import net.minecraft.text.Text;
@@ -27,6 +28,15 @@ public class Colors {
                         .build()
                 ).build();
     }
+    public static MiniMessage miniMessage(TagResolver[] tags) {
+        Builder tagBuilder = TagResolver.builder();
+        for (TagResolver tag : tags) {
+            tagBuilder.resolver(tag);
+        }
+        TagResolver tagResolver = tagBuilder.build();
+
+        return MiniMessage.builder().tags(tagResolver).build();
+    }
 
     public static MinecraftServerAudiences getServerAudience() {
         if (serverAudiences == null) return null;
@@ -45,7 +55,13 @@ public class Colors {
     }
 
     public static Component deserialize(String value) {
+        // for normal handler
         return miniMessage().deserialize(value);
+    }
+
+    public static Component deserialize(String value, TagResolver[] tags) {
+        // for server handler
+        return miniMessage(tags).deserialize(value);
     }
 
     public static Text toNative(Component component) {

--- a/src/main/java/fi/natroutter/chromaanvils/utilities/Utils.java
+++ b/src/main/java/fi/natroutter/chromaanvils/utilities/Utils.java
@@ -7,6 +7,43 @@ public class Utils {
 
     public static String extractWithTags(String input, int amount) {
         StringBuilder result = new StringBuilder();
+        int visibleCharCount = 0;
+
+        // Regex pattern to match both tags and regular text
+        Pattern pattern = Pattern.compile("<[^>]+>|[^<]+");
+        Matcher matcher = pattern.matcher(input);
+
+        // Process each match (either tag or regular text)
+        while (matcher.find()) {
+            String match = matcher.group();
+
+            // If it's a tag, add it fully to the result
+            if (match.startsWith("<") && match.endsWith(">")) {
+                result.append(match);
+            }
+            // If it's regular text, check if adding it exceeds the allowed length
+            else {
+                for (char c : match.toCharArray()) {
+                    if (visibleCharCount < amount) {
+                        result.append(c);
+                        visibleCharCount++;
+                    } else {
+                        break;
+                    }
+                }
+            }
+
+            // If we reached the desired length, stop processing
+            if (visibleCharCount >= amount) {
+                break;
+            }
+        }
+
+        return result.toString();
+    }
+
+    public static String extractWithTags2(String input, int amount) {
+        StringBuilder result = new StringBuilder();
         Pattern pattern = Pattern.compile("<[^>]+>|[^<]+");
         Matcher matcher = pattern.matcher(input);
         int count = 0;

--- a/src/main/resources/chromaanvils.mixins.json
+++ b/src/main/resources/chromaanvils.mixins.json
@@ -4,6 +4,12 @@
   "package": "fi.natroutter.chromaanvils.mixins",
   "compatibilityLevel": "JAVA_21",
   "mixins": [
+
+  ],
+  "server": [
+    "AnvilScreenHandlerServerMixin"
+  ],
+  "client": [
     "AnvilScreenMixin",
     "AnvilScreenHandlerMixin"
   ],


### PR DESCRIPTION
## Description

Simply put, I needed granular permissions instead of just `chromaanvils.use`. So I added it in. Now, you will find that you will need to give players the following permissions in order for ChromaAnvils to work:

```properties
# this one is still required for ANY tag resolver to work
chromaanvils.use

# give permission based on which tag resolver you want them to have access to
chromaanvils.colors
chromaanvils.decorations
chromaanvils.font
chromaanvils.gradient
chromaanvils.rainbow
chromaanvils.transition
chromaanvils.reset
```

So, if a player has `chromaanvils.use`, `chromaanvils.colors` and `chromaanvils.reset` (but nothing else; all other perms are false), then renaming an item to `<blue><strikethrough>Big<reset>Axe` will output this:
<img width="357" alt="image" src="https://github.com/user-attachments/assets/983bae77-ec9b-4b74-8555-8b44927fdea2" />

## Technical Implementation
- Added new method `private TagResolver[] GetTagsFromPlayerPermissions(ServerPlayerEntity player)` under AnvilScreenHandlerServerMixin, which checks the player's Permissions and returns a list of TagResolvers that can be applied for this player.
- Added new method `public static Component deserialize(String value, TagResolver[] tags)` under Colors, which takes in the tag resolvers from the above method, and then passes it to the miniMessage instance to build
- Added new method `public static MiniMessage miniMessage(TagResolver[] tags)` under Colors which builds a new miniMessage instance like usual but only takes in the tags from the args.
- Tested on a MC 1.21.4 server with `fabric-api-0.115.0+1.21.4` and `LuckPerms-Fabric-5.4.150` for the permissions.
- Please keep in mind I forked from the branch `origin/1.21.4` and not from `master`. So previous commits from that branch are included in this PR